### PR TITLE
Longest continious subset that adds up to zero

### DIFF
--- a/data-structures/Find the Unique Element
+++ b/data-structures/Find the Unique Element
@@ -1,0 +1,32 @@
+/*
+Given an integer array of size 2N + 1. In this given array, 
+N numbers are present twice and one number is present only once in the array.
+You need to find and return that number which is unique in the array.
+*/
+
+#include<iostream>
+#include <algorithm>
+#include "solution.h"
+using namespace std;
+
+int FindUnique(int arr[], int size){
+    int xor1 = 0;
+    for(int i = 0; i < size; i++)
+        xor1 ^= arr[i];
+    return xor1;
+}
+
+int main() {
+
+	int size;
+
+	cin>>size;
+	int *input=new int[1+size];	
+	
+	for(int i=0;i<size;i++)
+		cin>>input[i];
+	
+	cout<<FindUnique(input,size)<<endl;
+		
+	return 0;
+}

--- a/data-structures/hashmaps/longest-continious-subset-to-zero
+++ b/data-structures/hashmaps/longest-continious-subset-to-zero
@@ -1,0 +1,51 @@
+/*
+Given an array consisting of positive and negative integers, find the length of the longest continuous subset whose sum is zero.
+To be done in O(n) time complexity.
+
+Eg: Array size: 10 
+    Array: 95 -97 -387 -435 -5 -70 897 127 23 284
+    Then the length longest continious subset/sequence which sums up to zero is 5
+    Since the longest continious subset which sums up to zero is -387 -435 -5 -70 897.
+
+This program makes use of hashmaps and the STL is unordered_map.
+*/
+#include<iostream>
+#include <unordered_map>
+using namespace std;
+
+int lengthOfLongestSubsetWithZeroSum(int* arr, int size){
+    unordered_map<int, int> mymap;
+    int sum = 0;
+    int maxLength = -1;
+    for(int i = 0; i < size; i++){
+        sum += arr[i];
+        int length = 0;
+        
+        if(sum == 0){
+            length = i+1;
+        }else if(mymap.count(sum)){
+            length = i - mymap[sum];
+
+        }else{
+            mymap[sum] = i;
+        }
+
+        if(length > maxLength){
+            maxLength = length;
+        }
+    }
+    return maxLength;
+}
+
+int main(){
+  int size;
+  
+  cin >> size;
+  int* arr = new int[size];
+  for(int i = 0; i < size; i++){
+    cin >> arr[i];
+  }
+  int ans = lengthOfLongestSubsetWithZeroSum(arr,size);
+  cout << ans << endl;
+  delete arr;
+}


### PR DESCRIPTION
Given an array consisting of positive and negative integers, find the length of the longest continuous subset whose sum is zero.
To be done in O(n) time complexity. The use of hash-maps helps bring down the complexity to O(n).
Eg: Array size: 10 
    Array: 95 -97 -387 -435 -5 -70 897 127 23 284
    Then the length longest continious subset/sequence which sums up to zero is 5
    Since the longest continious subset which sums up to zero is -387 -435 -5 -70 897.

This program makes use of hashmaps and the STL is unordered_map.

<!--------------------------------------------------------

Thanks for contributing to the All ▲lgorithms Project

Make sure you fill the require information
---------------------------------------------------------->

This pull request is: <!-- THIS IS REQUIRE -->

<!-- Mark one by adding an [x] -->

- [x] A new Algorithm
- [ ] An update to an existing algorithm.
- [ ] An error fix
- [ ] Other (Describe below*)

This pull request fixes:

<!-- Enter the issue number which this pull request fixes -->

**Changes:**

<!-- Make sure you follow the contributing and code of conduct of this project -->
